### PR TITLE
fix removing toast correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,16 @@ const client = new QueryClient({
     }
   }),
 });
-
+const withDismiss = () => {
+  toast((t) => (
+    <span>
+      Custom and <b>bold</b>
+      <button onClick={() => toast.dismiss(t.id)}>
+        Dismiss2
+      </button>
+    </span>
+  ));
+}
 const App = () => {
   useQuery({
     queryKey: ['foo'],
@@ -39,9 +48,9 @@ const App = () => {
   });
   return (
     <div>
-      <button onClick={() => {
-              promise()
-      }}>Boom</button>
+      <button onClick={promise}>Boom</button>
+      <button onClick={withDismiss}>With Dismiss</button>
+      <MakeAndRemove />
       <Toaster />
     </div>
   );
@@ -52,3 +61,18 @@ export default () => (
     <App />
   </QueryClientProvider>
 );
+
+
+function MakeAndRemove() {
+ 
+  return <button onClick={ () => {
+    toast(
+    ({id}) => (
+      <div className="bg-green-500">
+        <p>Hello!</p>
+        <button onClick={() => toast.remove(id)}>Remove Me</button>
+      </div>
+    ),
+    {ttl: 3000}
+  )}}>Add And Remove</button>
+}

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -105,9 +105,7 @@ export const reducer = (state: State, action: Action): State => {
       }
       return {
         ...state,
-        toasts: toasts
-        .filter((t) => t.id !== action.toastId)
-
+        toasts: toasts.filter((t) => t.id !== action.toastId)
       };
     }
     case ActionType.START_PAUSE: {
@@ -127,7 +125,6 @@ export const reducer = (state: State, action: Action): State => {
 };
 
 function compensateForPausedTime(toasts: Toast[], pausedAt: number ) {
-  debugger;
   return toasts.map(t => {
     const newToast = {
       ...t,

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -93,12 +93,21 @@ export const reducer = (state: State, action: Action): State => {
       };
     }
     case ActionType.REMOVE_TOAST: {
+      const isPaused = state.pausedAt !== undefined
+      let toasts = state.toasts;
+      if (isPaused) {
+          toasts = compensateForPausedTime(state.toasts, state.pausedAt ?? 0)
+      }
+
+      
       if (action.toastId === undefined) {
         return { ...state, toasts: [] };
       }
       return {
         ...state,
-        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+        toasts: toasts
+        .filter((t) => t.id !== action.toastId)
+
       };
     }
     case ActionType.START_PAUSE: {
@@ -108,18 +117,27 @@ export const reducer = (state: State, action: Action): State => {
       };
     }
     case ActionType.END_PAUSE: {
-      const diff = action.time - (state.pausedAt || 0);
       return {
         ...state,
         pausedAt: undefined,
-        toasts: state.toasts.map((t) => ({
-          ...t,
-          pauseDuration: t.pauseDuration + diff,
-        })),
+        toasts: compensateForPausedTime(state.toasts, state.pausedAt ?? 0),
       };
     }
   }
 };
+
+function compensateForPausedTime(toasts: Toast[], pausedAt: number ) {
+  debugger;
+  return toasts.map(t => {
+    const newToast = {
+      ...t,
+      // adding old pauseDuration allows for multiple pause-resume cycles
+      pauseDuration: Date.now() - pausedAt + t.pauseDuration
+    }
+    return newToast
+  })
+}
+
 
 export const dispatch = (action: Action) => {
   memoryState = reducer(memoryState, action);

--- a/src/core/use-toaster.ts
+++ b/src/core/use-toaster.ts
@@ -12,8 +12,9 @@ export const useToaster = (toastOptions?: DefaultToastOptions) => {
       return true;
     }
 
+    const expiresAt = toast.createdAt + (toast.ttl || 0) + toast.pauseDuration;
     return (
-      Date.now() < toast.createdAt + (toast.ttl || 0) + toast.pauseDuration
+       expiresAt >= Date.now()
     );
   }, []);
 


### PR DESCRIPTION
fixes https://github.com/timolins/react-hot-toast/issues/367 from upstream


I've had a look and found out that this fix only works correctly if you remove all toasts, which `toast.remove` does as it's overloaded (undefined removes all). Actually I would prefer `removeById`, but that's another discussion.

I found out that what is not happening is that when you click 'remove' the PAUSE_END action is not fired (onMouseLeave is not triggered).

Either fire this action on remove and dismiss, or extract the logic of this PAUSE_END into a separate function and reuse.

You need to do this because the current fix does not count on the `pauseDuration` being adjusted. This is revealed when you remove by id and then they all disappear at once after the largest pause, which is not the desired behaviour.


Finally, this is a really tricky bug because `dismiss' is also affected, but because dismiss hides the toast, you accidentally trigger END_PAUSE because wrapper is there and onMouseLeave triggers.
